### PR TITLE
Major overhaul and upgrade to new version of Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,4 @@
 [root]
 name = "token"
-version = "1.0.0-rc1"
+version = "1.0.0-rc2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name            = "token"
-version         = "1.0.0-rc1"
+version         = "1.0.0-rc2"
 authors         = ["Jakob Lautrup Nysom <jaln@itu.dk>"]
 readme          = "README.md"
 documentation   = "https://machtan.github.io/token-rs/token"

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ extern crate token;
 let separators = vec![' ', '\n', '\t', '\r'];
 let source: &str = "    Hello world \n  How do you do\t-Finely I hope";
 
-let mut tokenizer = tokenizer::Tokenizer::new(source.as_bytes(), separators);
+let mut tokenizer = token::Tokenizer::new(source.as_bytes(), separators);
 println!("Tokenizing...");
-for token in tokenizer {
-    println!("- Got token: {}", token.unwrap());
+loop {
+    let token = match tokenizer.next().unwrap() {
+        Some(token) => token,
+        None => { break; }
+    };
+    println!("- Got token: {}", token);
 }
 println!("Done!");
 ```


### PR DESCRIPTION
 - Removed Iterator interface, since new rules prevent them.
 - Flattened some control structures and made it generally nicer.
 - Updated some documentation.
 - Fixed example in `README.md`.